### PR TITLE
updated unifile to fix relative path _exec() calls

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ javacOptions ++= Seq("-source", "11", "-target", "11")
 
 //ThisBuild / envFileName   := "dev.env" // sbt-dotenv plugin gets build environment here
 ThisBuild / scalaVersion  := scalaVer
-ThisBuild / version       := "0.10.16"
+ThisBuild / version       := "0.10.17"
 ThisBuild / versionScheme := Some("semver-spec")
 
 ThisBuild / organization         := "org.vastblue"
@@ -79,7 +79,7 @@ lazy val root = (project in file(".")).
 
 libraryDependencies ++= Seq(
   "org.scalatest"            %% "scalatest"       % "3.2.19" % Test,
-  "org.vastblue"              % "unifile_3"       % "0.3.6",
+  "org.vastblue"              % "unifile_3"       % "0.3.7",
   "org.simpleflatmapper"      % "sfm-csv"         % "9.0.2",
   "com.github.tototoshi"     %% "scala-csv"       % "2.0.0",
   "io.github.chronoscala"    %% "chronoscala"     % "2.0.10",


### PR DESCRIPTION
New version of unifile fixes `Platform._exec()` arg zero problem (problem only occurred in Windows, now fixed).