### PR TITLE
update-literal-version-strings-in-scripts-and-README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Leverages `vastblue.unifile.Paths.get()` to support both `posix` and `Windows` f
 
 To use `pallet` in an `SBT` project, add this dependency to `build.sbt`
 ```sbt
-  "org.vastblue" % "pallet_3" % "0.10.16"
+  "org.vastblue" % "pallet_3" % "0.10.17"
 ```
 For `scala` or `scala-cli` scripts, see examples below.
 
@@ -41,7 +41,7 @@ Simplicity and Universal Portability:
 ```scala
 #!/usr/bin/env -S scala-cli shebang
 
-//> using dep "org.vastblue::pallet::0.10.16"
+//> using dep "org.vastblue::pallet::0.10.17"
 import vastblue.pallet.*
 
   printf("uname / osType / osName:\n%s\n", s"platform info: ${unameLong} / ${osType} / ${osName}")
@@ -232,7 +232,7 @@ Some differences to be aware of between `scala-cli` scripts and conventional `sc
 For a per-user classpath `atFile`, define your classpath in a file named, e.g., `/Users/username/.scala3cp`.
 To include the `scala3` version of this library, for example, the `@file` might contain:
 ```
--classpath /Users/username/.ivy2/local/org.vastblue/pallet_3/0.10.16/jars/pallet_3.jar
+-classpath /Users/username/.ivy2/local/org.vastblue/pallet_3/0.10.17/jars/pallet_3.jar
 ```
 With this configuration, your scala 3 `shebang` line will look like this:
 ```scala
@@ -271,7 +271,7 @@ object Fstab {
 #!/ usr / bin / env -S scala -cli shebang
 
 //> using scala "3.4.3"
-//> using dep "org.vastblue::pallet::0.10.16"
+//> using dep "org.vastblue::pallet::0.10.17"
 
 import vastblue.pallet.*
 import vastblue.Platform.*
@@ -303,7 +303,7 @@ Note that on Darwin, there is no `/etc/fstab` file, so the `Path#lines` extensio
 #!/usr/bin/env -S scala-cli shebang
 
 //> using scala "3.4.3"
-//> using dep "org.vastblue::pallet::0.10.16"
+//> using dep "org.vastblue::pallet::0.10.17"
 
 import vastblue.pallet.*
 

--- a/jsrc/bashPath.sc
+++ b/jsrc/bashPath.sc
@@ -2,7 +2,7 @@
 //package vastblue.demo
 
 //> using scala "3.4.3"
-//> using lib "org.vastblue::pallet::0.10.16"
+//> using dep "org.vastblue::pallet::0.10.17"
 
 import vastblue.pallet.*
 

--- a/jsrc/bashPathCli.sc
+++ b/jsrc/bashPathCli.sc
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S scala-cli shebang
 
 //> using scala "3.4.3"
-//> using lib "org.vastblue::pallet::0.10.16"
+//> using dep "org.vastblue::pallet::0.10.17"
 
 import vastblue.pallet.*
 

--- a/jsrc/fstabCli.sc
+++ b/jsrc/fstabCli.sc
@@ -1,8 +1,8 @@
 #!/usr/bin/env -S scala-cli shebang
 
 //> using scala "3.4.3"
-//> using dep "org.vastblue::unifile::0.3.6"
-//> using dep "org.vastblue::pallet::0.10.16"
+//> using dep "org.vastblue::unifile::0.3.7"
+//> using dep "org.vastblue::pallet::0.10.17"
 
 //import vastblue.pallet.*
 import vastblue.unifile.*

--- a/jsrc/palletRef.sc
+++ b/jsrc/palletRef.sc
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S scala-cli shebang
 
 //> using scala "3.4.3"
-//> using lib "org.vastblue::pallet::0.10.16"
+//> using dep "org.vastblue::pallet::0.10.17"
 
 import vastblue.pallet._
 

--- a/jsrc/palletRefCli.sc
+++ b/jsrc/palletRefCli.sc
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S scala-cli shebang
 
 //> using scala "3.4.3"
-//> using lib "org.vastblue::pallet::0.10.16"
+//> using dep "org.vastblue::pallet::0.10.17"
 
 import vastblue.pallet.*
 

--- a/jsrc/sbt2cs.sc
+++ b/jsrc/sbt2cs.sc
@@ -8,11 +8,11 @@ import vastblue.unifile.*
  *   + fetch and list dependency file paths
  *   + convert sbt dependencies to scala-cli "using dep" format
  *
- * Example conversion from sbt dependency format to scala-cli lib format:
+ * Example conversion from sbt dependency format to scala-cli dep format:
  *
  * from:
- *   org.vastblue             %% unifile       % 0.3.6
- *   org.vastblue             %% pallet        % 0.10.16
+ *   org.vastblue             %% unifile       % 0.3.7
+ *   org.vastblue             %% pallet        % 0.10.17
  *   org.scalanlp             %% breeze-viz    % 2.1.0
  *   org.scalanlp             %% breeze        % 2.1.0
  *   org.scala-lang.modules   %% scala-xml     % 2.2.0
@@ -23,8 +23,8 @@ import vastblue.unifile.*
  *   com.github.darrenjw      %% scala-glm     % 0.8
  *
  * to:
- *   //> using dep "org.vastblue::pallet::0.10.16"
- *   //> using dep "org.vastblue::unifile::0.3.6"
+ *   //> using dep "org.vastblue::pallet::0.10.17"
+ *   //> using dep "org.vastblue::unifile::0.3.7"
  *   //> using dep "org.scalanlp::breeze-viz::2.1.0"
  *   //> using dep "org.scalanlp::breeze::2.1.0"
  *   //> using dep "org.scala-lang.modules::scala-xml::2.2.0"
@@ -40,7 +40,7 @@ object Sbt2cs {
       "[<inputFile>]",
      s"[-sbt [<sbt-sourcefile>]   ; default: ${defaultSbtSource}",
      s"[-cli]                     ; convert sbt deps to scala-cli format",
-     s"[-fetch]                   ; fetch and list lib jars",
+     s"[-fetch]                   ; fetch and list dep jars",
     ))
   }
   var (op, inputFile) = ("", "")

--- a/jsrc/unameGreeting.sc
+++ b/jsrc/unameGreeting.sc
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S scala
 
 //> using scala "3.4.3"
-//> using lib "org.vastblue::pallet::0.10.16"
+//> using dep "org.vastblue::pallet::0.10.17"
 
 import vastblue.pallet.*
 


### PR DESCRIPTION
replace literal version string for `unifile` and `pallet`, which appears in some demo scripts and in `README`
eliminate warnings re: `using dep` rather than `using lib` in scripts.