### PR TITLE
updated docs, scripts and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,142 +28,77 @@ Leverages `vastblue.unifile.Paths.get()` to support both `posix` and `Windows` f
 
 To use `pallet` in an `SBT` project, add this dependency to `build.sbt`
 ```sbt
-  "org.vastblue" % "pallet_3" % "0.10.18"
+  "org.vastblue" % "pallet"  %% "0.10.19" // scala 3
+  "org.vastblue" % "pallet_3" % "0.10.19" // scala 2.13.x
 ```
-For `scala` or `scala-cli` scripts, see examples below.
 
-## TL;DR
+## Summary
 Simplicity and Universal Portability:
 * Use `scala` instead of `bash` or `python` for portable general purpose scripting
 * Publish universal scala scripts, rather than multiple OS-customized versions
 * Script as though you're running in Linux, even on Windows or Mac.
-* Convenient runtime branching based on runtime environment:
-```scala
-#!/usr/bin/env -S scala-cli shebang
+* standard OS and platform variables, based on `uname` information
+* directly read csv file rows from `java.nio.file.Path` objects
+Extends the range of scala scripting:
+* reference Windows filesystem paths via posix abstractions
+* predefined environment information:
+  * osType: String     
+  * osName: String     
+  * scalaHome: String
+  * javaHome: String 
+  * userhome: String 
+  * username: String 
+  * hostname: String 
+  * uname: String
+  * shellRoot: String 
+  * isLinux: Boolean   
+  * isWinshell: Boolean
+  * isDarwin: Boolean  
+  * isWsl: Boolean     
+  * isCygwin: Boolean 
+  * isMsys: Boolean   
+  * isMingw: Boolean  
+  * isGitSdk: Boolean 
+  * isGitbash: Boolean
+  * isWindows: Boolean
+  * verbose: Boolean 
 
-//> using dep "org.vastblue::pallet::0.10.18"
-import vastblue.pallet.*
+* extension methods on `java.nio.file.Path` and `java.io.File`
+  * name: String
+  * basename: String // drop extension
+  * parent: Path
+  * lines: Iterator[String]
+  * md5: String
+  * sha256: String
+  * cksum: Long
+  * lastModified: Long
+  * newerThan(other: Path): Boolean
+  * olderThan(other: Path): Boolean
+  * lastModifiedMillisAgo: Long
+  * lastModSecondsAgo: Double
+  * lastModMinutesAgo: Double
+  * lastModHoursAgo: Double
+  * lastModDaysAgo: Double
+  * withFileWriter(p: Path)(func: PrintWriter => Any)
+  * append DATA to script file
+  * many others
+* iterate directory subfiles:
+  * files: Iterator[JFile]
+  * paths: Iterator[Path]
+  * walkTree(file: JFile, depth: Int = 1, maxdepth: Int = -1): Iterable[JFile]
+  * walkTreeFiltered(file: JFile, depth: Int = 1, maxdepth: Int = -1)(filt: JFile => Boolean): Iterable[JFile]
+  * walkTreeFast(p: Path, tossDirs: Set[String], maxdepth: Int = -1)(filt: Path => Boolean)
 
-  printf("uname / osType / osName:\n%s\n", s"platform info: ${unameLong} / ${osType} / ${osName}")
-  if (isLinux) {
-    // uname is "Linux"
-    printf("hello Linux\n")
-  } else if (isDarwin) {
-    // uname is "Darwin*"
-    printf("hello Mac\n")
-  } else if (isWinshell) {
-    // isWinshell: Boolean = isMsys | isCygwin | isMingw | isGitSdk | isGitbash
-    printf("hello %s\n", unameShort)
-  } else if (envOrEmpty("MSYSTEM").nonEmpty) {
-    printf("hello %s\n", envOrEmpty("MSYSTEM"))
-  } else {
-    assert(isWindows, s"unknown environment: ${unameLong} / ${osType} / ${osName}")
-    printf("hello Windows\n")
-  }
-```
-* extends the range of scala scripting:
-Example: read process command lines from `/proc/$PID/cmdline` files
-```scala
-#!/usr/bin/env -S scala -deprecation -cp target/scala-3.4.3/classes
+* read files in the `/proc` tree in Windows, e.g.:
+  * `/proc/meminfo`
+  * `/proc/$PID/cmdline`
 
-import vastblue.pallet.*
-import vastblue.file.ProcfsPaths.cmdlines
-
-var verbose = false
-def main(args: Array[String]): Unit = {
-  for (arg <- args) {
-    arg match {
-    case "-v" =>
-      verbose = true
-    }
-  }
-  if (isLinux || isWinshell) {
-    printf("script name: %s\n\n", scriptName)
-    // find /proc/[0-9]+/cmdline files
-    for ((procfile, cmdline) <- cmdlines) {
-      if (verbose || cmdline.contains(scriptName)) {
-        printf("%s\n", procfile)
-        printf("%s\n\n", cmdline)
-      }
-    }
-  } else {
-    printf("procfs filesystem not supported in os [%s]\n", osType)
-  }
-}
-```
-```bash
-$ jsrc/procCmdline.sc
-```
-output when run from a Windows `Msys64` bash session:
-```scala
-script name: jsrc/procCmdline.sc
-
-/proc/32314/cmdline
-'C:\opt\jdk\bin\java.exe' '-Dscala.home=C:/opt/scala' '-classpath' 'C:/opt/scala/lib/scala-library-2.13.10.jar;C:/opt/scala/lib/scala3-library_3-3.4.3.jar;C:/opt/scala/lib/scala-asm-9.5.0-scala-1.jar;C:/opt/scala/lib/compiler-interface-1.3.5.jar;C:/opt/scala/lib/scala3-interfaces-3.4.3.jar;C:/opt/scala/lib/scala3-compiler_3-3.4.3.jar;C:/opt/scala/lib/tasty-core_3-3.4.3.jar;C:/opt/scala/lib/scala3-staging_3-3.4.3.jar;C:/opt/scala/lib/scala3-tasty-inspector_3-3.4.3.jar;C:/opt/scala/lib/jline-reader-3.19.0.jar;C:/opt/scala/lib/jline-terminal-3.19.0.jar;C:/opt/scala/lib/jline-terminal-jna-3.19.0.jar;C:/opt/scala/lib/jna-5.3.1.jar;;' 'dotty.tools.MainGenericRunner' '-classpath' 'C:/opt/scala/lib/scala-library-2.13.10.jar;C:/opt/scala/lib/scala3-library_3-3.4.3.jar;C:/opt/scala/lib/scala-asm-9.5.0-scala-1.jar;C:/opt/scala/lib/compiler-interface-1.3.5.jar;C:/opt/scala/lib/scala3-interfaces-3.4.3.jar;C:/opt/scala/lib/scala3-compiler_3-3.4.3.jar;C:/opt/scala/lib/tasty-core_3-3.4.3.jar;C:/opt/scala/lib/scala3-staging_3-3.4.3.jar;C:/opt/scala/lib/scala3-tasty-inspector_3-3.4.3.jar;C:/opt/scala/lib/jline-reader-3.19.0.jar;C:/opt/scala/lib/jline-terminal-3.19.0.jar;C:/opt/scala/lib/jline-terminal-jna-3.19.0.jar;C:/opt/scala/lib/jna-5.3.1.jar;;' '-deprecation' '-cp' 'target/scala-3.4.3/classes' './procCmdline.sc'
-
-/proc/32274/cmdline
-'bash' '/c/opt/scala/bin/scala' '-deprecation' '-cp' 'target/scala-3.4.3/classes' './procCmdline.sc'
-```
-Example #2: write and read `.csv` files:
-```scala
-#!/usr/bin/env -S scala -cp target/scala-3.4.3/classes
-//package vastblue
-
-import vastblue.pallet.*
-
-object CsvWriteRead {
-  def main(args: Array[String]): Unit = {
-    val testFiles = Seq("tabTest.csv", "commaTest.csv")
-    for (filename <- testFiles){
-      val testFile: Path = filename.toPath
-
-      if (!testFile.exists) {
-        // create tab-delimited and comma-delimited test files
-        val delim: String = if filename.startsWith("tab") then "\t" else ","
-        testFile.withWriter() { w =>
-          w.printf(s"1st${delim}2nd${delim}3rd\n")
-          w.printf(s"A${delim}B${delim}C\n")
-        }
-      }
-
-      assert(testFile.isFile)
-      printf("\n# filename: %s\n", testFile.norm)
-      // display file text lines
-      for ((line: String, i: Int) <- testFile.lines.zipWithIndex){
-        printf("%d: %s\n", i, line)
-      }
-      // display file csv rows
-      for (row: Seq[String] <- testFile.csvRows){
-        printf("%s\n", row.mkString("|"))
-      }
-    }
-  }
-}
-```
-```bash
-$ time jsrc/csvWriteRead.sc
-```
-Output:
-```bash
-# filename: C:/Users/username/workspace/pallet/tabTest.csv
-0: 1st  2nd     3rd
-1: A    B       C
-1st|2nd|3rd
-A|B|C
-
-# filename: C:/Users/username/workspace/pallet/commaTest.csv
-0: 1st,2nd,3rd
-1: A,B,C
-1st|2nd|3rd
-A|B|C
-
-real    0m4.269s
-user    0m0.135s
-sys     0m0.411s
-```
 ## Requirements
-In Windows, requires a posix shell:
-  ([MSYS64](https://msys2.org), [CYGWIN64](https://www.cygwin.com), or `WSL`)
+In Windows, requires installing a posix shell:
+  * [MSYS64](https://msys2.org)
+  * [CYGWIN64](https://www.cygwin.com)
+  * [WSL](https://learn.microsoft.com/en-us/windows/wsl/install)
+  * [Git Bash](https://gitforwindows.org/)
 
 In `Darwin/OSX`, requires `homebrew` or similar.
 
@@ -176,8 +111,6 @@ Best with a recent version of coreutils:
 * `vastblue.file.Paths` is a `java.nio.file.Paths` drop-in replacement that:
   * correctly handles mounted `posix` paths
   * returns ordinary `java.nio.file.Path` objects
-
-Examples below illustrate some of the capabilities.
 
 ### Background
 If you work in diverse environments, you generally must customize scripts for each environment:
@@ -193,61 +126,41 @@ Most platforms other than `Windows` are unix-like, but:
 
 This library provides the missing piece.
 
-Choices to be made when using `scala` as a general purpose scripting language include:
- * how to manage the classpath
- * learning cross-platform coding techniques
-
 ### The Classpath
-The various approaches to managing classpaths fall into two categories.
-In addition to installing scripts, client systems must either:
-  * install `scala-cli`
-  * install required jars plus an associated `@atFile`
+When using `scala-cli`, the classpath is fully managed for you.
+For java version 9 or above, you can also define the classpath in a java options file.
+When specifying an options file for `Darwin/Osx`, the `@atFile` path must be absolute.
 
-If `scala-cli` is installed, the classpath is fully managed for you.
-If required jars plus associated `@atFile` are installed, your scripts must either:
-  * reference `@<path-to-atFile>` in the `shebang` line
-  * set environment variable `SCALA_OPTS=@<path-to-atFile>`
-
-To support `Darwin/Osx`, an absolute path to an `@atFile` is required in the `shebang` line.
 Example portable `shebang` line:
-   `#!/usr/bin/env -S scala @/opt/atFiles/.scala3cp`
-
-Alternatively, if `SCALA_OPTS` is defined:
-   `#!/usr/bin/env -S scala`
+   `#!/usr/bin/env -S scala @/opt/atFiles/scala3cp`
 
 ### Setup for running the example scripts:
-A good option for writing scala scripts is `scala-cli`, and some example scripts are written for it.
-Each `scala-cli` script specifies required dependency internally, and the classpath is managed for you.
+There are various ways to write scala3 script `hash-bang` lines:
 
-A `scala-cli` alternative is to create an `@atFile` containing the `-classpath` definition.
+  `#!/usr/bin/env -S scala-cli shebang`
+  `#!/usr/bin/env -S scala`
+  `#!/usr/bin/env -S scala @/opt/scalaAtfile`
 
-Some differences to be aware of between `scala-cli` scripts and conventional `scala` scripts:
+For scala versions 3.5+, the first two variations are roughly (exactly?) equivalent.
+For versions 3.4.3 and earlier, the 3rd form defines the `classpath` in an options file.
+
+Each `scala-cli` script specifies required dependencies internally, and the classpath is managed for you.
+
+Some differences to be aware of between `scala-cli` scripts and legacy `scala` scripts:
   * a `scala-cli` script declares dependencies within the script via special comments
-  * if `main()` is defined, it must be explicitly called within a `scala-cli` script
-  * startup times the two script types differ, even after the initial compile invocation.  On my Windows box:
-    * 4 seconds for `scala-cli` before printing `hello world`
-    * 2 seconds for scala scripts (`SCALA_CLI=-save @/Users/username/scala3cp`)
-
-### Defining the classpath
-For a per-user classpath `atFile`, define your classpath in a file named, e.g., `/Users/username/.scala3cp`.
-To include the `scala3` version of this library, for example, the `@file` might contain:
-```
--classpath /Users/username/.ivy2/local/org.vastblue/pallet_3/0.10.18/jars/pallet_3.jar
-```
-With this configuration, your scala 3 `shebang` line will look like this:
-```scala
-#!/usr/bin/env -S scala @${HOME}/scala3cp
-```
-
-In `Darwin/Osx` the `${HOME}` path must be explicit, due to `/usr/bin/env` semantics.
-The alternative is to reference the `@atFile` via `SCALA_OPTS=@/Users/username/scala3cp` rather than in the `shebang` line.
-
-Examples below assume classpath and other options are defined by the `SCALA_CLI` variable.
-
-Note that if `classpath` is also defined in the `shebang` line, it will append to the classpath defined in `SCALA_CLI`.
+  * if a `main()` method is defined, `scala-cli` requires it to be explicitly called at package level.
 
 ### Example script: display the native path and the number of lines in `/etc/fstab`
-This example might surprise developers working in a `Windows` posix shell, since `jvm` languages normally cannot see posix file paths that aren't also legal `Windows` paths.
+If you work in a `Windows` posix shell, you are aware that `java.nio.file.Paths.get()` expects file path String to be legal `Windows` paths.
+
+The following command line should print `true` to the Console:
+```scala
+scala -e 'println(java.nio.file.Paths.get("C:/Windows").toFile.isDirectory)'
+```
+and the following command line will print `false`:
+```scala
+scala -e 'println(java.nio.file.Paths.get("/etc/fstab").toFile.isFile)'
+```
 
 ```scala
 #!/ usr / bin / env -S scala
@@ -271,7 +184,7 @@ object Fstab {
 #!/ usr / bin / env -S scala -cli shebang
 
 //> using scala "3.4.3"
-//> using dep "org.vastblue::pallet::0.10.18"
+//> using dep "org.vastblue::pallet::0.10.19"
 
 import vastblue.pallet.*
 import vastblue.Platform.*
@@ -303,7 +216,7 @@ Note that on Darwin, there is no `/etc/fstab` file, so the `Path#lines` extensio
 #!/usr/bin/env -S scala-cli shebang
 
 //> using scala "3.4.3"
-//> using dep "org.vastblue::pallet::0.10.18"
+//> using dep "org.vastblue::pallet::0.10.19"
 
 import vastblue.pallet.*
 
@@ -375,6 +288,7 @@ The `-save` option saves the compiled script to a `jar` file in the script paren
     * [MSYS64](https://msys2.org)
     * [CYGWIN64](https://www.cygwin.com)
     * [WSL](https://learn.microsoft.com/en-us/windows/wsl/install)
+    * [Git Bash](https://gitforwindows.org/)
   * `Linux`: required packages:
     * `sudo apt install coreutils`
   * `Darwin/OSX`:
@@ -400,4 +314,124 @@ Things that maximize the odds of your script running on another system:
     * this avoids exposure to the `Windows` jvm glob expansion bug, and
     * inserts `script` path or `main` method class as `argv(0)` (as in C/C++)
     * argv(0) script name available as input parameter affecting script behaviour
+### Examples
+Examples below illustrate some of the capabilities.
 
+```scala
+#!/usr/bin/env -S scala-cli shebang
+
+//> using dep "org.vastblue::pallet::0.10.19"
+import vastblue.pallet.*
+
+  printf("uname / osType / osName:\n%s\n", s"platform info: ${unameLong} / ${osType} / ${osName}")
+  if (isLinux) {
+    // uname is "Linux"
+    printf("hello Linux\n")
+  } else if (isDarwin) {
+    // uname is "Darwin*"
+    printf("hello Mac\n")
+  } else if (isWinshell) {
+    // isWinshell: Boolean = isMsys | isCygwin | isMingw | isGitSdk | isGitbash
+    printf("hello %s\n", unameShort)
+  } else if (envOrEmpty("MSYSTEM").nonEmpty) {
+    printf("hello %s\n", envOrEmpty("MSYSTEM"))
+  } else {
+    assert(isWindows, s"unknown environment: ${unameLong} / ${osType} / ${osName}")
+    printf("hello Windows\n")
+  }
+```
+```scala
+#!/usr/bin/env -S scala-cli shebang
+
+//> using dep "org.vastblue::pallet::0.10.19"
+import vastblue.pallet.*
+
+import vastblue.pallet.*
+import vastblue.file.ProcfsPaths.cmdlines
+
+var verbose = false
+for (arg <- args) {
+  arg match {
+  case "-v" =>
+    verbose = true
+  }
+}
+if (isLinux || isWinshell) {
+  printf("script name: %s\n\n", scriptName)
+  // find /proc/[0-9]+/cmdline files
+  for ((procfile, cmdline) <- cmdlines) {
+    if (verbose || cmdline.contains(scriptName)) {
+      printf("%s\n", procfile)
+      printf("%s\n\n", cmdline)
+    }
+  }
+} else {
+  printf("procfs filesystem not supported in os [%s]\n", osType)
+}
+```
+```bash
+$ jsrc/procCmdline.sc
+```
+output when run from a Windows `Msys64` bash session:
+```scala
+script name: jsrc/procCmdline.sc
+
+/proc/32314/cmdline
+'C:\opt\jdk\bin\java.exe' '-Dscala.home=C:/opt/scala' '-classpath' 'C:/opt/scala/lib/scala-library-2.13.10.jar;C:/opt/scala/lib/scala3-library_3-3.4.3.jar;C:/opt/scala/lib/scala-asm-9.5.0-scala-1.jar;C:/opt/scala/lib/compiler-interface-1.3.5.jar;C:/opt/scala/lib/scala3-interfaces-3.4.3.jar;C:/opt/scala/lib/scala3-compiler_3-3.4.3.jar;C:/opt/scala/lib/tasty-core_3-3.4.3.jar;C:/opt/scala/lib/scala3-staging_3-3.4.3.jar;C:/opt/scala/lib/scala3-tasty-inspector_3-3.4.3.jar;C:/opt/scala/lib/jline-reader-3.19.0.jar;C:/opt/scala/lib/jline-terminal-3.19.0.jar;C:/opt/scala/lib/jline-terminal-jna-3.19.0.jar;C:/opt/scala/lib/jna-5.3.1.jar;;' 'dotty.tools.MainGenericRunner' '-classpath' 'C:/opt/scala/lib/scala-library-2.13.10.jar;C:/opt/scala/lib/scala3-library_3-3.4.3.jar;C:/opt/scala/lib/scala-asm-9.5.0-scala-1.jar;C:/opt/scala/lib/compiler-interface-1.3.5.jar;C:/opt/scala/lib/scala3-interfaces-3.4.3.jar;C:/opt/scala/lib/scala3-compiler_3-3.4.3.jar;C:/opt/scala/lib/tasty-core_3-3.4.3.jar;C:/opt/scala/lib/scala3-staging_3-3.4.3.jar;C:/opt/scala/lib/scala3-tasty-inspector_3-3.4.3.jar;C:/opt/scala/lib/jline-reader-3.19.0.jar;C:/opt/scala/lib/jline-terminal-3.19.0.jar;C:/opt/scala/lib/jline-terminal-jna-3.19.0.jar;C:/opt/scala/lib/jna-5.3.1.jar;;' '-deprecation' '-cp' 'target/scala-3.4.3/classes' './procCmdline.sc'
+
+/proc/32274/cmdline
+'bash' '/c/opt/scala/bin/scala' '-deprecation' '-cp' 'target/scala-3.4.3/classes' './procCmdline.sc'
+```
+Example #2: write and read `.csv` files:
+```scala
+#!/usr/bin/env -S scala-cli shebang
+
+//> using dep "org.vastblue::pallet::0.10.19"
+import vastblue.pallet.*
+
+val testFiles = Seq("tabTest.csv", "commaTest.csv")
+for (filename <- testFiles){
+  val testFile: Path = filename.toPath
+
+  if (!testFile.exists) {
+    // create tab-delimited and comma-delimited test files
+    val delim: String = if filename.startsWith("tab") then "\t" else ","
+    testFile.withWriter() { w =>
+      w.printf(s"1st${delim}2nd${delim}3rd\n")
+      w.printf(s"A${delim}B${delim}C\n")
+    }
+  }
+
+  assert(testFile.isFile)
+  printf("\n# filename: %s\n", testFile.norm)
+  // display file text lines
+  for ((line: String, i: Int) <- testFile.lines.zipWithIndex){
+    printf("%d: %s\n", i, line)
+  }
+  // display file csv rows
+  for (row: Seq[String] <- testFile.csvRows){
+    printf("%s\n", row.mkString("|"))
+  }
+}
+```
+```bash
+$ time jsrc/csvWriteRead.sc
+```
+Output:
+```bash
+# filename: C:/Users/username/workspace/pallet/tabTest.csv
+0: 1st  2nd     3rd
+1: A    B       C
+1st|2nd|3rd
+A|B|C
+
+# filename: C:/Users/username/workspace/pallet/commaTest.csv
+0: 1st,2nd,3rd
+1: A,B,C
+1st|2nd|3rd
+A|B|C
+
+real    0m4.269s
+user    0m0.135s
+sys     0m0.411s
+```

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ javacOptions ++= Seq("-source", "11", "-target", "11")
 
 //ThisBuild / envFileName   := "dev.env" // sbt-dotenv plugin gets build environment here
 ThisBuild / scalaVersion  := scalaVer
-ThisBuild / version       := "0.10.18"
+ThisBuild / version       := "0.10.19"
 ThisBuild / versionScheme := Some("semver-spec")
 
 ThisBuild / organization         := "org.vastblue"
@@ -79,7 +79,7 @@ lazy val root = (project in file(".")).
 
 libraryDependencies ++= Seq(
   "org.scalatest"            %% "scalatest"       % "3.2.19" % Test,
-  "org.vastblue"              % "unifile_3"       % "0.3.8",
+  "org.vastblue"              % "unifile_3"       % "0.3.9",
   "org.simpleflatmapper"      % "sfm-csv"         % "9.0.2",
   "com.github.tototoshi"     %% "scala-csv"       % "2.0.0",
   "io.github.chronoscala"    %% "chronoscala"     % "2.0.10",

--- a/jsrc/bashPath.sc
+++ b/jsrc/bashPath.sc
@@ -2,7 +2,7 @@
 //package vastblue.demo
 
 //> using scala "3.4.3"
-//> using dep "org.vastblue::pallet::0.10.18"
+//> using dep "org.vastblue::pallet::0.10.19"
 
 import vastblue.pallet.*
 

--- a/jsrc/bashPathCli.sc
+++ b/jsrc/bashPathCli.sc
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S scala-cli shebang
 
 //> using scala "3.4.3"
-//> using dep "org.vastblue::pallet::0.10.18"
+//> using dep "org.vastblue::pallet::0.10.19"
 
 import vastblue.pallet.*
 

--- a/jsrc/fstabCli.sc
+++ b/jsrc/fstabCli.sc
@@ -2,7 +2,7 @@
 
 //> using scala "3.4.3"
 //> using dep "org.vastblue::unifile::0.3.8"
-//> using dep "org.vastblue::pallet::0.10.18"
+//> using dep "org.vastblue::pallet::0.10.19"
 
 //import vastblue.pallet.*
 import vastblue.unifile.*

--- a/jsrc/palletRef.sc
+++ b/jsrc/palletRef.sc
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S scala-cli shebang
 
 //> using scala "3.4.3"
-//> using dep "org.vastblue::pallet::0.10.18"
+//> using dep "org.vastblue::pallet::0.10.19"
 
 import vastblue.pallet._
 

--- a/jsrc/palletRefCli.sc
+++ b/jsrc/palletRefCli.sc
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S scala-cli shebang
 
 //> using scala "3.4.3"
-//> using dep "org.vastblue::pallet::0.10.18"
+//> using dep "org.vastblue::pallet::0.10.19"
 
 import vastblue.pallet.*
 

--- a/jsrc/sbt2cs.sc
+++ b/jsrc/sbt2cs.sc
@@ -12,7 +12,7 @@ import vastblue.unifile.*
  *
  * from:
  *   org.vastblue             %% unifile       % 0.3.8
- *   org.vastblue             %% pallet        % 0.10.18
+ *   org.vastblue             %% pallet        % 0.10.19
  *   org.scalanlp             %% breeze-viz    % 2.1.0
  *   org.scalanlp             %% breeze        % 2.1.0
  *   org.scala-lang.modules   %% scala-xml     % 2.2.0
@@ -23,7 +23,7 @@ import vastblue.unifile.*
  *   com.github.darrenjw      %% scala-glm     % 0.8
  *
  * to:
- *   //> using dep "org.vastblue::pallet::0.10.18"
+ *   //> using dep "org.vastblue::pallet::0.10.19"
  *   //> using dep "org.vastblue::unifile::0.3.8"
  *   //> using dep "org.scalanlp::breeze-viz::2.1.0"
  *   //> using dep "org.scalanlp::breeze::2.1.0"
@@ -86,7 +86,7 @@ com.github.darrenjw      %% scala-glm     % 0.8
 org.scala-lang.modules   %% scala-swing   % 3.0.0
 net.ruippeixotog         %% scala-scraper % 3.1.1
 org.vastblue             %% unifile       % 0.3.8
-org.vastblue             %% pallet        % 0.10.18
+org.vastblue             %% pallet        % 0.10.19
 """.trim.split("[\r\n]+").toList.filter { _.nonEmpty }
 
   def parseArgs(args: Seq[String]): Unit = {

--- a/jsrc/unameGreeting.sc
+++ b/jsrc/unameGreeting.sc
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S scala
 
 //> using scala "3.4.3"
-//> using dep "org.vastblue::pallet::0.10.18"
+//> using dep "org.vastblue::pallet::0.10.19"
 
 import vastblue.pallet.*
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.5
+sbt.version=1.10.7


### PR DESCRIPTION
De-emphasize legacy scripting in README and example scripts
much more detail for `Path` and `File` extension methods
